### PR TITLE
deps: Change the flexfloat submodule url to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/flexfloat"]
 	path = deps/flexfloat
-	url = git@github.com:oprecomp/flexfloat.git
+	url = https://github.com/oprecomp/flexfloat.git


### PR DESCRIPTION
Change the URL of the submodule to HTTPS to not require an SSH key in the CI.

After fetching this commit, use `git submodule sync --recursive` to update the URL in your existing installation.