### PR TITLE
engine: Add barrier CSR, fix cluster peripherals

### DIFF
--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -4278,6 +4278,7 @@ pub enum Csr {
     Mhartid = 0xf14,
     Ssr = 0x7c0,
     Fpmode = 0x7c1,
+    Barrier = 0x7c2,
     Htimedeltah = 0x615,
     Cycleh = 0xc80,
     Timeh = 0xc81,


### PR DESCRIPTION
This MR:

* Integrates the new CSR-based cluster barrier in Banshee (https://github.com/pulp-platform/snitch_cluster/pull/43)
* Fixes peripheral accesses: They did not properly respect the `offset` field, making e.g. zero memory accesses report out-of-map errors.

Note that the CSR address is currently hacked into `riscv.rs` manually, but the resulting generated file should be identical once https://github.com/pulp-platform/riscv-opcodes/pull/9 is merged.