### PR TITLE
FIX: downgrade termion due to breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rev_slice = "0.1.5"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.63"
 serde_yaml = "0.8"
-termion = "*"
+termion = "2.0.3"
 thiserror = "1.0.21"
 to-binary = "0.4.0"
 


### PR DESCRIPTION
The latest update of the `termion` crate introduces breaking changes, which cause the build of `banshee` to fail.  