### PR TITLE
Update Rust to 1.67 to keep up with "cc"'s requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.63.0   # minimum supported version
+        - 1.67.0   # minimum supported version
     steps:
     - uses: actions/checkout@v3
       with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Banshee is a binary-translation-based, instruction-accurate RISC-V simulator for
 
 ## Requirements
 
-Banshee currently requires Rust version 1.63.0 and LLVM 12.
+Banshee currently requires Rust version 1.67.0 and LLVM 12.
 
 To install Rust, visit [Rustup](https://rustup.rs/) and choose the correct version of Rust during the installation process.
 
@@ -16,10 +16,10 @@ If you already have Rust installed, get the specific version of the Rust with:
 
 ```bash
 # Install the correct Rust version
-rustup install 1.63.0
+rustup install 1.67.0
 
 # Change default toolchain version
-rustup default 1.63.0
+rustup default 1.67.0
 ```
 
 To get LLVM on Ubuntu, install the following packages:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.67.0"
 components = [ "rustfmt" ]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -113,7 +113,7 @@ impl Engine {
                 );
 
                 // Parse the module.
-                let mut module = std::mem::MaybeUninit::uninit().assume_init();
+                let mut module = std::mem::MaybeUninit::zeroed().assume_init();
                 let mut errmsg = std::mem::MaybeUninit::zeroed().assume_init();
                 if LLVMParseIRInContext(self.context, initial_buf, &mut module, &mut errmsg) != 0
                     || !errmsg.is_null()
@@ -171,7 +171,7 @@ impl Engine {
                 );
 
                 // Parse the module.
-                let mut runtime = std::mem::MaybeUninit::uninit().assume_init();
+                let mut runtime = std::mem::MaybeUninit::zeroed().assume_init();
                 let mut errmsg = std::mem::MaybeUninit::zeroed().assume_init();
                 if LLVMParseIRInContext(self.context, runtime_buf, &mut runtime, &mut errmsg) != 0
                     || !errmsg.is_null()
@@ -337,7 +337,7 @@ impl Engine {
         debug!("Creating JIT compiler for translated code");
         let execs: Vec<_> = (0..self.num_clusters)
             .map(|i| {
-                let mut ee = std::mem::MaybeUninit::uninit().assume_init();
+                let mut ee = std::mem::MaybeUninit::zeroed().assume_init();
                 let mut errmsg = std::mem::MaybeUninit::zeroed().assume_init();
                 let optlevel = if self.opt_jit { 3 } else { 0 };
                 LLVMCreateJITCompilerForModule(&mut ee, self.modules[i], optlevel, &mut errmsg);


### PR DESCRIPTION
This updates the required Rust version to v1.67.0 to keep up with packages that are dropping support for older versions.

The "cc" dependency recently [updated their Rust requirement](https://github.com/rust-lang/cc-rs/issues/1144), which broke the [snitch_cluster container](https://github.com/pulp-platform/snitch_cluster/actions/runs/9841222732/job/27167326073?pr=158).

